### PR TITLE
Eq for Token & TokenType

### DIFF
--- a/src/Text/Highlighter/Types.hs
+++ b/src/Text/Highlighter/Types.hs
@@ -44,7 +44,7 @@ data Token =
         { tType :: TokenType
         , tText :: BS.ByteString
         }
-    deriving Show
+    deriving (Show, Eq)
 
 data TokenType
     = Text
@@ -158,7 +158,7 @@ data TokenType
 
     -- Use another lexer to yield some tokens
     | Using Lexer
-    deriving Show
+    deriving (Show, Eq)
 
 instance Show Lexer where
     show l = "(Lexer " ++ lName l ++ ")"


### PR DESCRIPTION
I wanted to compare token types (to find comments for jml/difftodo). It's much easier to do this if `TokenType` has `Eq`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chemist/highlighter/3)

<!-- Reviewable:end -->
